### PR TITLE
Fix equality of dates

### DIFF
--- a/src/Implementation/String/DateTimeValue.php
+++ b/src/Implementation/String/DateTimeValue.php
@@ -74,7 +74,7 @@ abstract class DateTimeValue implements \ADS\ValueObjects\DateTimeValue
             return false;
         }
 
-        return $this->toDateTime() === $other->toDateTime();
+        return $this->toDateTime() == $other->toDateTime();
     }
 
     /**


### PR DESCRIPTION
We should not be checking if the two objects are the exact same object. As valueobjects, they are equal if they are the same class and have the same internal values.